### PR TITLE
fix: Echo after wg-quick up command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ runs:
               echo "${{ inputs.WG_CONFIG_FILE }}" > wg0.conf
               sudo chmod 600 wg0.conf
               echo "setting config"
-              sudo wg-quick up ./wg0.conf
+              sudo wg-quick up ./wg0.conf && echo "wg-quick setup successful"
           shell: bash
 
 branding:


### PR DESCRIPTION
I don't know when problem started, but in last jobs using this action(another open-source wg actions too) was stucked. After some testing and applying echo in end of command - job successful